### PR TITLE
Bugfix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,8 @@ on:
               default: 0
               type: number
   push:
-      branches: [ master ]
+    # all branches
+      branches: '**'
 #   pull_request:
 #     branches: [ master ]
 

--- a/liberty/lib/LoopProf/LoopProfiling.cpp
+++ b/liberty/lib/LoopProf/LoopProfiling.cpp
@@ -271,6 +271,10 @@ bool LoopProf::runOnModule(Module& M)
         // FIXME: more proper way is to see if a function call followed by unreachable
         if (fcn->getName().equals("__cxa_throw"))
           continue;
+
+        // FIXME: handle this properly
+        if (fcn->getName().equals("_setjmp") || fcn->getName().equals("setjmp") || fcn->getName().equals("longjmp") || fcn->getName().equals("_longjmp"))
+          continue;
       }
 
       Args[0] = ConstantInt::get(Type::getInt32Ty(M.getContext()), numLoops );

--- a/liberty/lib/Orchestration/PSDSWPCritic.cpp
+++ b/liberty/lib/Orchestration/PSDSWPCritic.cpp
@@ -745,65 +745,6 @@ void PSDSWPCritic::simplifyPDG(PDG *pdg) {
   std::string sccdagDotName = "optimistic_sccdag_" + header->getName().str() +
                               "_" + fcn->getName().str() + ".dot";
 
-  // go through all the nodes and see if they still have potential dependences
-  // This is for SLAMP profiling, to estimate how many nodes can be ignored
-/*
- *   auto numAllNode = 0;
- *   auto numElidedNode = 0;
- *   for (auto node : optimisticPDG->getNodes()) {
- *     bool canBeElided = true;
- *     
- *     DGEdge<Value> *blockingEdge;
- *     if (dyn_cast<Instruction>(node->getT())->mayReadOrWriteMemory()) {
- *       numAllNode++;
- *     } else {
- *       continue;
- *     }
- * 
- *     if (dyn_cast<Instruction>(node->getT())->mayWriteToMemory()) {
- *       for (auto &edge : node->getOutgoingEdges()) {
- *         if (edge->isRAWDependence()) {
- *           canBeElided = false;
- *           blockingEdge = edge;
- *           break;
- *         }
- *       }
- *     }
- * 
- *     if (dyn_cast<Instruction>(node->getT())->mayReadFromMemory()) {
- *       for (auto &edge : node->getIncomingEdges()) {
- *         if (edge->isRAWDependence()) {
- *           canBeElided = false;
- *           blockingEdge = edge;
- *           break;
- *         }
- *       }
- *     }
- * 
- *     if (canBeElided) {
- *       REPORT_DUMP(
- *           errs() << "Node can be ignored for memory profiling" << *node->getT();
- *           liberty::printInstDebugInfo(dyn_cast<Instruction>(node->getT()));
- *           errs() << '\n';);
- *       numElidedNode++;
- *     }
- *     else {
- * 
- *       REPORT_DUMP(errs() << "Blocking edge: " << *blockingEdge->getOutgoingT();
- *                   if (Instruction *outgoingI =
- *                           dyn_cast<Instruction>(blockingEdge->getOutgoingT()))
- *                       liberty::printInstDebugInfo(outgoingI);
- * 
- *                   errs() << "\n    to " << *blockingEdge->getIncomingT();
- *                   if (Instruction *incomingI =
- *                           dyn_cast<Instruction>(blockingEdge->getIncomingT()))
- *                       liberty::printInstDebugInfo(incomingI);
- *                   errs() << "\n";);
- *     }
- *   }
- *   REPORT_DUMP(errs() << "Elided Node: " << numElidedNode << "/" << numAllNode
- *                      << "\n";);
- */
   writeGraph<SCCDAG, SCC>(sccdagDotName, optimisticSCCDAG);
 }
 

--- a/liberty/lib/Orchestration/PSDSWPCritic.cpp
+++ b/liberty/lib/Orchestration/PSDSWPCritic.cpp
@@ -746,61 +746,64 @@ void PSDSWPCritic::simplifyPDG(PDG *pdg) {
                               "_" + fcn->getName().str() + ".dot";
 
   // go through all the nodes and see if they still have potential dependences
-  auto numAllNode = 0;
-  auto numElidedNode = 0;
-  for (auto node : optimisticPDG->getNodes()) {
-    bool canBeElided = true;
-    
-    DGEdge<Value> *blockingEdge;
-    if (dyn_cast<Instruction>(node->getT())->mayReadOrWriteMemory()) {
-      numAllNode++;
-    } else {
-      continue;
-    }
-
-    if (dyn_cast<Instruction>(node->getT())->mayWriteToMemory()) {
-      for (auto &edge : node->getOutgoingEdges()) {
-        if (edge->isRAWDependence()) {
-          canBeElided = false;
-          blockingEdge = edge;
-          break;
-        }
-      }
-    }
-
-    if (dyn_cast<Instruction>(node->getT())->mayReadFromMemory()) {
-      for (auto &edge : node->getIncomingEdges()) {
-        if (edge->isRAWDependence()) {
-          canBeElided = false;
-          blockingEdge = edge;
-          break;
-        }
-      }
-    }
-
-    if (canBeElided) {
-      REPORT_DUMP(
-          errs() << "Node can be ignored for memory profiling" << *node->getT();
-          liberty::printInstDebugInfo(dyn_cast<Instruction>(node->getT()));
-          errs() << '\n';);
-      numElidedNode++;
-    }
-    else {
-
-      REPORT_DUMP(errs() << "Blocking edge: " << *blockingEdge->getOutgoingT();
-                  if (Instruction *outgoingI =
-                          dyn_cast<Instruction>(blockingEdge->getOutgoingT()))
-                      liberty::printInstDebugInfo(outgoingI);
-
-                  errs() << "\n    to " << *blockingEdge->getIncomingT();
-                  if (Instruction *incomingI =
-                          dyn_cast<Instruction>(blockingEdge->getIncomingT()))
-                      liberty::printInstDebugInfo(incomingI);
-                  errs() << "\n";);
-    }
-  }
-  REPORT_DUMP(errs() << "Elided Node: " << numElidedNode << "/" << numAllNode
-                     << "\n";);
+  // This is for SLAMP profiling, to estimate how many nodes can be ignored
+/*
+ *   auto numAllNode = 0;
+ *   auto numElidedNode = 0;
+ *   for (auto node : optimisticPDG->getNodes()) {
+ *     bool canBeElided = true;
+ *     
+ *     DGEdge<Value> *blockingEdge;
+ *     if (dyn_cast<Instruction>(node->getT())->mayReadOrWriteMemory()) {
+ *       numAllNode++;
+ *     } else {
+ *       continue;
+ *     }
+ * 
+ *     if (dyn_cast<Instruction>(node->getT())->mayWriteToMemory()) {
+ *       for (auto &edge : node->getOutgoingEdges()) {
+ *         if (edge->isRAWDependence()) {
+ *           canBeElided = false;
+ *           blockingEdge = edge;
+ *           break;
+ *         }
+ *       }
+ *     }
+ * 
+ *     if (dyn_cast<Instruction>(node->getT())->mayReadFromMemory()) {
+ *       for (auto &edge : node->getIncomingEdges()) {
+ *         if (edge->isRAWDependence()) {
+ *           canBeElided = false;
+ *           blockingEdge = edge;
+ *           break;
+ *         }
+ *       }
+ *     }
+ * 
+ *     if (canBeElided) {
+ *       REPORT_DUMP(
+ *           errs() << "Node can be ignored for memory profiling" << *node->getT();
+ *           liberty::printInstDebugInfo(dyn_cast<Instruction>(node->getT()));
+ *           errs() << '\n';);
+ *       numElidedNode++;
+ *     }
+ *     else {
+ * 
+ *       REPORT_DUMP(errs() << "Blocking edge: " << *blockingEdge->getOutgoingT();
+ *                   if (Instruction *outgoingI =
+ *                           dyn_cast<Instruction>(blockingEdge->getOutgoingT()))
+ *                       liberty::printInstDebugInfo(outgoingI);
+ * 
+ *                   errs() << "\n    to " << *blockingEdge->getIncomingT();
+ *                   if (Instruction *incomingI =
+ *                           dyn_cast<Instruction>(blockingEdge->getIncomingT()))
+ *                       liberty::printInstDebugInfo(incomingI);
+ *                   errs() << "\n";);
+ *     }
+ *   }
+ *   REPORT_DUMP(errs() << "Elided Node: " << numElidedNode << "/" << numAllNode
+ *                      << "\n";);
+ */
   writeGraph<SCCDAG, SCC>(sccdagDotName, optimisticSCCDAG);
 }
 

--- a/liberty/lib/SLAMP/SLAMPlib/hooks/slamp_hooks.cpp
+++ b/liberty/lib/SLAMP/SLAMPlib/hooks/slamp_hooks.cpp
@@ -1534,8 +1534,7 @@ void* SLAMP_malloc(size_t size, uint32_t instr, size_t alignment)
 
 void  SLAMP_free(void* ptr)
 {
-  __malloc_hook = old_malloc_hook;
-  __free_hook = old_free_hook;
+  TURN_OFF_CUSTOM_MALLOC;
   
   uint64_t starting_page;
   unsigned purge_cnt;
@@ -1546,6 +1545,5 @@ void  SLAMP_free(void* ptr)
       smmap->deallocate_pages(starting_page, purge_cnt);
   }
 
-  __malloc_hook = SLAMP_malloc_hook;
-  __free_hook = SLAMP_free_hook;
+  TURN_ON_CUSTOM_MALLOC;
 }

--- a/tests/scripts/slamp-driver
+++ b/tests/scripts/slamp-driver
@@ -188,8 +188,8 @@ while IFS=$'\n' read -r line_data; do
 done < __targets.txt
 
 let i=0
-while (( i < 2 )); do
-# while (( ${#lines[@]} > i )); do
+# while (( i < 2 )); do
+while (( ${#lines[@]} > i )); do
   IFS=' ' read -a array <<< ${lines[i++]}
   if [ ${array[0]} == "-" ]; then
     drive $1 ${array[1]} ${array[3]}


### PR DESCRIPTION
Multiple bug fixes:

- LoopProf
   520.omnetpp uses setjmp/longjmp, need to ignore them in the loopProf otherwise the context would be messed up.
- SLAMP points-to
   SLAMP ignored all memory allocation outside of the targeted loop due to missing context. Now set `SLAMP_push` and `SLAMP_pop` for all external unrecognized functions (including malloc, and other ones that may allocate objects). The objects are now correctly tracked.
- SLAMP script
   Was tracking only the top loop. Now doing all.