### PR TITLE
Bug fix in EdmondsKarp algorithm

### DIFF
--- a/liberty/.clangd
+++ b/liberty/.clangd
@@ -1,0 +1,5 @@
+CompileFlags:                     # Tweak the parse settings
+  Add: [-Wold-style-cast]                   # treat all files as C++, enable more warnings
+Diagnostics:
+  ClangTidy:
+    Add: bugprone-*

--- a/liberty/lib/Orchestration/PSDSWPCritic.cpp
+++ b/liberty/lib/Orchestration/PSDSWPCritic.cpp
@@ -94,6 +94,7 @@ struct IsParallel {
 
   bool operator()(const SCC &scc) const {
     for (auto edge : make_range(scc.begin_edges(), scc.end_edges())) {
+      // all internal dependences must be intra-iteration
       if (!scc.isInternal(edge->getIncomingT()) ||
           !scc.isInternal(edge->getOutgoingT()))
         continue;
@@ -1170,12 +1171,8 @@ void PSDSWPCritic::adjustForRegLCFromSeqToPar(PipelineStrategy &ps, PDG &pdg,
                                               PipelineStage *firstStage,
                                               PipelineStage *parallelStage) {
   std::vector<Instruction *> moveToSeqInsts;
-  for (PipelineStage::ISet::const_iterator
-           j = parallelStage->instructions.begin(),
-           z = parallelStage->instructions.end();
-       j != z; ++j) {
-    Instruction *inst = *j;
-    auto *pdgNode = pdg.fetchConstNode(inst);
+  for (auto inst : parallelStage->instructions) {
+     auto *pdgNode = pdg.fetchConstNode(inst);
 
     // There should be no loop-carried edge
     for (auto edge : make_range(pdgNode->begin_incoming_edges(),


### PR DESCRIPTION
Fix bug in EdmonsKarp algorithm.
The `VertexAndFlow` type was defined as `std::pair<Vertex,double>`, when a previous bug fix changes `INFINITY` to `~0UL` instead of `~0U`, the conversion from unsigned int to double then back to unsigned int will overflow and set to 0 (`(unsigned int)(double)(~0UL) = 0`).

Also in this fix, a clangd configuration file is added to warn this case by adding `bugprone-*` to ClangTidy.